### PR TITLE
osx support

### DIFF
--- a/speedread
+++ b/speedread
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -CSA
+#!/usr/bin/env perl -CSA
 #
 # speedread:  A simple terminal-based open source spritz-alike
 #
@@ -219,12 +219,20 @@ sub new {
 	my $self;
 	open $self, '/dev/tty';
 	bless $self, $class;
-	eval { system('stty -F /dev/tty min 1 -icanon -echo'); };
+    if ($^O eq 'darwin') {
+        eval { system('stty -f /dev/tty min 1 -icanon -echo'); };
+    } else {
+        eval { system('stty -F /dev/tty min 1 -icanon -echo'); };
+    }
 	return $self;
 }
 
 sub DESTROY {
-	eval { system('stty -F /dev/tty cooked echo'); };
+    if ($^O eq 'darwin') {
+        eval { system('stty -f /dev/tty cooked echo'); };
+    } else {
+        eval { system('stty -F /dev/tty cooked echo'); };
+    }
 }
 
 sub key_pressed {


### PR DESCRIPTION
Hi,

Great script. I ran it on OSX and two things jumped out, so I fixed them. First my system Perl is 5.12, though I have 5.14 installed through Homebrew, so I changed the shebang to check `$PATH`. Also on OSX it is `stty -f`, not `stty -F`, so I added a switch for that.

Cheers,
Alex
