### PR TITLE
Support black-on-white terminal color schemes

### DIFF
--- a/speedread
+++ b/speedread
@@ -107,7 +107,8 @@ sub show_word {
 		. substr($word, 0, $i)
 		. color("red")
 		. $pivotch
-		. color("white")
+		. color("reset")
+		. color("bold")
 		. substr($word, $i+1)
 		. color("reset")
 		. " " x ($cursorpos - (($ORPvisualpos - $i) + length($word)))


### PR DESCRIPTION
With this change, the full text is readable when the terminal has a white background.
