### PR TITLE
Use utf8 encoding

### DIFF
--- a/speedread
+++ b/speedread
@@ -36,6 +36,7 @@ my $multiword = 0;
 
 
 use utf8;
+use encoding 'utf8';
 use encoding::warnings;
 binmode(STDIN, ":encoding(UTF-8)");
 binmode(STDOUT, ":encoding(UTF-8)");


### PR DESCRIPTION
Hello @pasky!

Thanks for the speedread!

_my perl experience is next to nil_ but..

I had this problem:

```
~/Applications/speedread ~/Desktop/text.txt -w 350
#!/usr/bin/env perl
                    v
Bytes implicitly upgraded into wide characters as iso-8859-1 at /Users/nfedyashev/Applications/speedread/speedread line 179.
            ÐºÐ¾ÑÐ¾ÑÑÐµ                                  350 wpm
```

and after some googling and this fix, it seems to be working now:

```
~/Applications/speedread/speedread ~/Desktop/text.txt -w 350
                    v
                   кто                                          350 wpm

file ~/Desktop/text.txt
/Users/nfedyashev/Desktop/text.txt: UTF-8 Unicode text, with very long lines
```

Probably there are better ways to fix it but it works now

HTH
