### PR TITLE
Added word_time behavior for question marks and colons.

### DIFF
--- a/speedread
+++ b/speedread
@@ -123,7 +123,7 @@ sub word_time {
 	my $time = $wordtime;
 	if ($word =~ /[\.\?]\W*$/) {
 		$time = $fstoptime;
-	} elsif ($word =~ /[;,]\W*$/) {
+	} elsif ($word =~ /[:;,]\W*$/) {
 		$time = $commatime;
 	} elsif ($word =~ / /) {
 		$time = $multitime;


### PR DESCRIPTION
Question marks should behave like full stops.
Colons should cause a longer word time, and seem to be equivalent to commas.
