### PR TITLE
Remove deprecated `use encoding`

### DIFF
--- a/speedread
+++ b/speedread
@@ -36,8 +36,6 @@ my $multiword = 0;
 
 
 use utf8;
-use encoding 'utf8';
-use encoding::warnings;
 binmode(STDIN, ":encoding(UTF-8)");
 binmode(STDOUT, ":encoding(UTF-8)");
 


### PR DESCRIPTION
Without this change a warning is displayed at the start and also at certain points while running (it seems to be the case at double newlines but I'm not 100% sure). The desired behavior should already be there because of `use utf8`.

I tested it on tea.txt using perl v5.24.0 and it works as intended.