### PR TITLE
Don't strip em-dash, pause on it

### DIFF
--- a/speedread
+++ b/speedread
@@ -127,11 +127,12 @@ sub word_time {
 	my ($word) = @_;
 
 	my $time = $wordtime;
-	if ($word =~ /[\.\?]\W*$/) {
+	# \x{2014} = mdash
+	if ($word =~ /(?:[\.\?]\W*$|--|\x{2014})/) {
 		$time = $fstoptime;
 	} elsif ($word =~ /[:;,]\W*$/) {
 		$time = $commatime;
-	} elsif ($word =~ / /) {
+	} elsif ($word =~ /[ -]/) {
 		$time = $multitime;
 	}
 	$time += sqrt(length($word)) * $lentime;
@@ -194,7 +195,7 @@ sub main {
 		unshift @lastlines, $_;
 		pop @lastlines if @lastlines > 2;
 
-		my (@words) = grep { /./ } split /(?:-|\s)+/;
+		my (@words) = grep { /./ } split /\s+/;
 
 		if ($multiword) {
 			# Join adjecent short words


### PR DESCRIPTION
Treat both `--` and `—` as if it were a sentence-ending mark, giving it a "full stop" length pause.

Also necessarily changes how hyphens work; don't strip them (hyphens are important!), but instead display them, pausing on the word using the `$multitime` pause.

This is the text I tested it with:
>"But this creature--" he nodded toward Dragonbait-- "is too large to be a familiar, and few sorcerers carry quite so much steel about their person."
>"This scroll was written by the hand of the Arch-cleric Mzentul himself.

Sorry if this change is too far-reaching. I just found it useful to properly display the book I was reading.