### PR TITLE
Pause after exclamation mark

### DIFF
--- a/speedread
+++ b/speedread
@@ -127,7 +127,7 @@ sub word_time {
 	my ($word) = @_;
 
 	my $time = $wordtime;
-	if ($word =~ /[\.\?]\W*$/) {
+	if ($word =~ /[.?!]\W*$/) {
 		$time = $fstoptime;
 	} elsif ($word =~ /[:;,]\W*$/) {
 		$time = $commatime;


### PR DESCRIPTION
Just like after `.` and `?`, pause after `!`.

Also, note that metacharacters need not be escaped inside character classes.